### PR TITLE
Added support for 5.0.1

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,4 @@
-https://github.com/Uninett/RT-Extension-ConditionalCustomFields.gituse inc::Module::Install;
+use inc::Module::Install;
 use utf8;
 
 RTx 'RT-Extension-ConditionalCustomFields';

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,4 @@
-use inc::Module::Install;
+https://github.com/Uninett/RT-Extension-ConditionalCustomFields.gituse inc::Module::Install;
 use utf8;
 
 RTx 'RT-Extension-ConditionalCustomFields';
@@ -6,7 +6,7 @@ license 'gpl_3';
 repository 'https://github.com/gibus/RT-Extension-ConditionalCustomFields';
 
 requires_rt('4.2.0');
-rt_too_new('4.6.0');
+rt_too_new('5.0.1');
 
 readme_from 'lib/RT/Extension/ConditionalCustomFields.pm', 0, 'md', 'README.md';
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,7 +6,7 @@ license 'gpl_3';
 repository 'https://github.com/gibus/RT-Extension-ConditionalCustomFields';
 
 requires_rt('4.2.0');
-rt_too_new('5.0.1');
+rt_too_new('5.0.2');
 
 readme_from 'lib/RT/Extension/ConditionalCustomFields.pm', 0, 'md', 'README.md';
 

--- a/README
+++ b/README
@@ -223,10 +223,14 @@ INSTALLATION
             cd /opt/rt4 # Your location may be different
             patch -p1 < /download/dir/RT-Extension-ConditionalCustomFields/patches/4.4.1-add-callbacks-to-extend-customfields-capabilities.patch
 
-        For RT 4.4.2 or greater, apply the included patch:
+        For RT 4.4.2, apply the included patch:
 
             cd /opt/rt4 # Your location may be different
             patch -p1 < /download/dir/RT-Extension-ConditionalCustomFields/patches/4.4.2-add-callbacks-to-extend-customfields-capabilities.patch
+         
+        For RT 5.0.1, apply the included patch
+        cd /opt/rt5 # Your location may be different
+        patch -p1 < /download/dir/RT-Extension-ConditionalCustomFields/patches/5.0.1-add-callbacks-to-extend-customfields-capabilities.patch
 
     Edit your /opt/rt4/etc/RT_SiteConfig.pm
         If you are using RT 4.2 or greater, add this line:

--- a/README
+++ b/README
@@ -229,6 +229,7 @@ INSTALLATION
             patch -p1 < /download/dir/RT-Extension-ConditionalCustomFields/patches/4.4.2-add-callbacks-to-extend-customfields-capabilities.patch
          
         For RT 5.0.1, apply the included patch
+        
         cd /opt/rt5 # Your location may be different
         patch -p1 < /download/dir/RT-Extension-ConditionalCustomFields/patches/5.0.1-add-callbacks-to-extend-customfields-capabilities.patch
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ Works with RT 4.2 or greater
 
         cd /opt/rt4 # Your location may be different
         patch -p1 < /download/dir/RT-Extension-ConditionalCustomFields/patches/4.4.2-add-callbacks-to-extend-customfields-capabilities.patch
+        
+    For RT 5.0.1, apply the included patch
+        
+        cd /opt/rt5 # Your location may be different
+        patch -p1 < /download/dir/RT-Extension-ConditionalCustomFields/patches/5.0.1-add-callbacks-to-extend-customfields-capabilities.patch
 
 - Edit your `/opt/rt4/etc/RT_SiteConfig.pm`
 

--- a/patches/5.0.1-add-callbacks-to-extend-customfields-capabilities.patch
+++ b/patches/5.0.1-add-callbacks-to-extend-customfields-capabilities.patch
@@ -1,0 +1,27 @@
+From 7900709683ae4a7cf14f6b598080dff472c474f1 Mon Sep 17 00:00:00 2001
+From: Wiggen94 <gjermundwiggen@gmail.com>
+Date: Wed, 5 May 2021 10:39:11 +0200
+Subject: [PATCH 2/2] Added callback to Modify.html
+
+---
+ share/html/Admin/CustomFields/Modify.html | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/share/html/Admin/CustomFields/Modify.html b/share/html/Admin/CustomFields/Modify.html
+index 90828c2..d23b147 100644
+--- a/share/html/Admin/CustomFields/Modify.html
++++ b/share/html/Admin/CustomFields/Modify.html
+@@ -349,7 +349,10 @@ else {
+ }
+
+ if ( $ARGS{'Update'} && $id ne 'new' ) {
+-
++
++    #add opportunity for extension to do something
++    $m->callback(CallbackName => 'Massage', CustomField => $CustomFieldObj, Results => \@results, ARGSRef => \%ARGS);
++
+     #we're asking about enabled on the web page but really care about disabled.
+     $ARGS{'Disabled'} = $Enabled? 0 : 1;
+
+--
+2.20.1


### PR DESCRIPTION
I've added support for 5.0.1 through a custom patch.
This patch only applies to `share/html/Admin/CustomFields/Modify.html`

I've not implemented it for `share/html/Articles/Article/Elements/EditCustomFields` or `share/html/Admin/Queues/Modify.html`

This allows for creation and usage of conditional custom fields.