### PR TITLE
Support for RT v5.0.3

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -36,6 +36,8 @@ META.yml
 patches/4.2-add-callbacksto-extend-customfields-capabilities.patch
 patches/4.4.1-add-callbacks-to-extend-customfields-capabilities.patch
 patches/4.4.2-add-callbacks-to-extend-customfields-capabilities.patch
+patches/5.0.1-add-callbacks-to-extend-customfields-capabilities.patch
+patches/5.0.3-add-callbacks-to-extend-customfields-capabilities.patch
 README
 README.md
 static/js/conditional-customfields.js

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,13 +6,13 @@ license 'gpl_3';
 repository 'https://github.com/gibus/RT-Extension-ConditionalCustomFields';
 
 requires_rt('4.2.0');
-rt_too_new('5.0.2');
+rt_too_new('5.0.4');
 
 readme_from 'lib/RT/Extension/ConditionalCustomFields.pm', 0, 'md', 'README.md';
 
 my ($lp) = ($INC{'RT.pm'} =~ /^(.*)[\\\/]/);
 my $lib_path = join( ' ', "$RT::LocalPath/lib", $lp );
-my $bin_path = $RT::BinPath || "$RT::BasePath/bin" || "/opt/rt4/bin";
+my $bin_path = $RT::BinPath || "$RT::BasePath/bin" || "/opt/rt4/bin" || "/opt/rt5/bin";
 
 # Straight from perldoc perlvar
 use Config;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,4 @@
-https://github.com/Uninett/RT-Extension-ConditionalCustomFields.gituse inc::Module::Install;
+use inc::Module::Install;
 use utf8;
 
 RTx 'RT-Extension-ConditionalCustomFields';

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,4 @@
-use inc::Module::Install;
+https://github.com/Uninett/RT-Extension-ConditionalCustomFields.gituse inc::Module::Install;
 use utf8;
 
 RTx 'RT-Extension-ConditionalCustomFields';
@@ -6,7 +6,7 @@ license 'gpl_3';
 repository 'https://github.com/gibus/RT-Extension-ConditionalCustomFields';
 
 requires_rt('4.2.0');
-rt_too_new('4.6.0');
+rt_too_new('5.0.1');
 
 readme_from 'lib/RT/Extension/ConditionalCustomFields.pm', 0, 'md', 'README.md';
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,7 +6,7 @@ license 'gpl_3';
 repository 'https://github.com/gibus/RT-Extension-ConditionalCustomFields';
 
 requires_rt('4.2.0');
-rt_too_new('5.0.1');
+rt_too_new('5.0.2');
 
 readme_from 'lib/RT/Extension/ConditionalCustomFields.pm', 0, 'md', 'README.md';
 

--- a/README
+++ b/README
@@ -232,6 +232,11 @@ INSTALLATION
         
         cd /opt/rt5 # Your location may be different
         patch -p1 < /download/dir/RT-Extension-ConditionalCustomFields/patches/5.0.1-add-callbacks-to-extend-customfields-capabilities.patch
+         
+        For RT 5.0.3, apply the included patch
+        
+        cd /opt/rt5 # Your location may be different
+        patch -p1 < /download/dir/RT-Extension-ConditionalCustomFields/patches/5.0.3-add-callbacks-to-extend-customfields-capabilities.patch
 
     Edit your /opt/rt4/etc/RT_SiteConfig.pm
         If you are using RT 4.2 or greater, add this line:

--- a/README
+++ b/README
@@ -223,10 +223,14 @@ INSTALLATION
             cd /opt/rt4 # Your location may be different
             patch -p1 < /download/dir/RT-Extension-ConditionalCustomFields/patches/4.4.1-add-callbacks-to-extend-customfields-capabilities.patch
 
-        For RT 4.4.2 or greater, apply the included patch:
+        For RT 4.4.2, apply the included patch:
 
             cd /opt/rt4 # Your location may be different
             patch -p1 < /download/dir/RT-Extension-ConditionalCustomFields/patches/4.4.2-add-callbacks-to-extend-customfields-capabilities.patch
+         
+        For RT 5.0.1, apply the included patch
+        cd /opt/rt5 # Your location may be different
+        patch -p1 < /download/dir/RT-Extension-ConditionalCustomFields/patches/5.0.1-add-callbacks-to-extend-customfields-capabilities.patch
 
     Edit your /opt/rt4/etc/RT_SiteConfig.pm
         If you are using RT 4.2 or greater, add this line:

--- a/README
+++ b/README
@@ -229,6 +229,7 @@ INSTALLATION
             patch -p1 < /download/dir/RT-Extension-ConditionalCustomFields/patches/4.4.2-add-callbacks-to-extend-customfields-capabilities.patch
          
         For RT 5.0.1, apply the included patch
+        
         cd /opt/rt5 # Your location may be different
         patch -p1 < /download/dir/RT-Extension-ConditionalCustomFields/patches/5.0.1-add-callbacks-to-extend-customfields-capabilities.patch
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ Works with RT 4.2 or greater
         
         cd /opt/rt5 # Your location may be different
         patch -p1 < /download/dir/RT-Extension-ConditionalCustomFields/patches/5.0.1-add-callbacks-to-extend-customfields-capabilities.patch
+        
+    For RT 5.0.3, apply the included patch
+        
+        cd /opt/rt5 # Your location may be different
+        patch -p1 < /download/dir/RT-Extension-ConditionalCustomFields/patches/5.0.3-add-callbacks-to-extend-customfields-capabilities.patch
 
 - Edit your `/opt/rt4/etc/RT_SiteConfig.pm`
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ Works with RT 4.2 or greater
 
         cd /opt/rt4 # Your location may be different
         patch -p1 < /download/dir/RT-Extension-ConditionalCustomFields/patches/4.4.2-add-callbacks-to-extend-customfields-capabilities.patch
+        
+    For RT 5.0.1, apply the included patch
+        
+        cd /opt/rt5 # Your location may be different
+        patch -p1 < /download/dir/RT-Extension-ConditionalCustomFields/patches/5.0.1-add-callbacks-to-extend-customfields-capabilities.patch
 
 - Edit your `/opt/rt4/etc/RT_SiteConfig.pm`
 

--- a/inc/Module/Install/RTx.pm
+++ b/inc/Module/Install/RTx.pm
@@ -53,7 +53,7 @@ sub RTx {
         my @look = @INC;
         unshift @look, grep {defined and -d $_} @try;
         push @look, grep {defined and -d $_}
-            map { ( "$_/rt4/lib", "$_/lib/rt4", "$_/lib" ) } @prefixes;
+            map { ( "$_/rt5/lib", "$_/lib/rt5", "$_/rt4/lib", "$_/lib/rt4", "$_/lib" ) } @prefixes;
         last if eval {local @INC = @look; require RT; $RT::LocalLibPath};
 
         warn

--- a/lib/RT/Extension/ConditionalCustomFields.pm
+++ b/lib/RT/Extension/ConditionalCustomFields.pm
@@ -98,6 +98,16 @@ For RT 4.4.2 or greater, apply the included patch:
     cd /opt/rt4 # Your location may be different
     patch -p1 < /download/dir/RT-Extension-ConditionalCustomFields/patches/4.4.2-add-callbacks-to-extend-customfields-capabilities.patch
 
+For RT 5.0.1 or 5.0.2, apply the included patch:
+
+    cd /opt/rt5 # Your location may be different
+    patch -p1 < /download/dir/RT-Extension-ConditionalCustomFields/patches/5.0.1-add-callbacks-to-extend-customfields-capabilities.patch
+
+For RT 5.0.3, apply the included patch:
+
+    cd /opt/rt5 # Your location may be different
+    patch -p1 < /download/dir/RT-Extension-ConditionalCustomFields/patches/5.0.3-add-callbacks-to-extend-customfields-capabilities.patch
+
 =item Edit your F</opt/rt4/etc/RT_SiteConfig.pm>
 
 If you are using RT 4.2 or greater, add this line:

--- a/patches/5.0.1-add-callbacks-to-extend-customfields-capabilities.patch
+++ b/patches/5.0.1-add-callbacks-to-extend-customfields-capabilities.patch
@@ -1,0 +1,27 @@
+From 7900709683ae4a7cf14f6b598080dff472c474f1 Mon Sep 17 00:00:00 2001
+From: Wiggen94 <gjermundwiggen@gmail.com>
+Date: Wed, 5 May 2021 10:39:11 +0200
+Subject: [PATCH 2/2] Added callback to Modify.html
+
+---
+ share/html/Admin/CustomFields/Modify.html | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/share/html/Admin/CustomFields/Modify.html b/share/html/Admin/CustomFields/Modify.html
+index 90828c2..d23b147 100644
+--- a/share/html/Admin/CustomFields/Modify.html
++++ b/share/html/Admin/CustomFields/Modify.html
+@@ -349,7 +349,10 @@ else {
+ }
+
+ if ( $ARGS{'Update'} && $id ne 'new' ) {
+-
++
++    #add opportunity for extension to do something
++    $m->callback(CallbackName => 'Massage', CustomField => $CustomFieldObj, Results => \@results, ARGSRef => \%ARGS);
++
+     #we're asking about enabled on the web page but really care about disabled.
+     $ARGS{'Disabled'} = $Enabled? 0 : 1;
+
+--
+2.20.1

--- a/patches/5.0.3-add-callbacks-to-extend-customfields-capabilities.patch
+++ b/patches/5.0.3-add-callbacks-to-extend-customfields-capabilities.patch
@@ -1,0 +1,40 @@
+diff --git a/lib/RT/CustomField.pm b/lib/RT/CustomField.pm
+index c0112ae..b4c3b1a 100644
+--- a/lib/RT/CustomField.pm
++++ b/lib/RT/CustomField.pm
+@@ -1560,7 +1560,7 @@ sub Groupings {
+         if ( my $record_config = $config->{$record_class} ) {
+             my @order;
+             for my $category ( $category, 'Default' ) {
+-                if ( $category && $record_config->{$category} ) {
++                if ( $category && ref($record_config) eq 'HASH' && $record_config->{$category} ) {
+                     @order = @{ $record_config->{$category} };
+                     last;
+                 }
+diff --git a/lib/RT/CustomFields.pm b/lib/RT/CustomFields.pm
+index 7615799..e8d4f95 100644
+--- a/lib/RT/CustomFields.pm
++++ b/lib/RT/CustomFields.pm
+@@ -138,7 +138,7 @@ sub LimitToGrouping {
+        $config = $config->{$grouping_class} || {};
+     my %h;
+     for my $category ( $category, 'Default' ) {
+-        if ( $category && $config->{$category} ) {
++        if ( $category && ref($config) eq 'HASH' && $config->{$category} ) {
+             %h = @{ $config->{$category} };
+             last;
+         }
+diff --git a/share/html/Admin/CustomFields/Modify.html b/share/html/Admin/CustomFields/Modify.html
+index d026f76..3d771aa 100644
+--- a/share/html/Admin/CustomFields/Modify.html
++++ b/share/html/Admin/CustomFields/Modify.html
+@@ -351,6 +351,9 @@ else {
+ 
+ if ( $ARGS{'Update'} && $id ne 'new' ) {
+ 
++    #add opportunity for extension to do something
++    $m->callback(CallbackName => 'Massage', CustomField => $CustomFieldObj, Results => \@results, ARGSRef => \%ARGS);
++
+     #we're asking about enabled on the web page but really care about disabled.
+     $ARGS{'Disabled'} = $Enabled? 0 : 1;
+ 


### PR DESCRIPTION
We have managed to make the extension work for RT version 5.0.3.
The work is done on top of [PR!](https://github.com/gibus/RT-Extension-ConditionalCustomFields/pull/10).

The main issue to make the extension work was the following error during the rendering of ticket creation page:
*An internal RT error has occurred. Your administrator can find more details in RT's log files.*
The log message was:
```
[29] [Thu Nov 10 12:46:19 2022] [error]: Not a HASH reference at /opt/rt5/sbin/../lib/RT/CustomFields.pm line 141.

Stack:
  [/opt/rt5/sbin/../lib/RT/CustomFields.pm:141]
  [/opt/rt5/share/html/Elements/EditCustomFields:97]
  [/opt/rt5/share/html/Ticket/Create.html:200]
  [/opt/rt5/share/html/Widgets/TitleBox:61]
  [/opt/rt5/share/html/Ticket/Create.html:243]
  [/opt/rt5/share/html/Ticket/autohandler:66]
  [/opt/rt5/sbin/../lib/RT/Interface/Web.pm:741]
  [/opt/rt5/sbin/../lib/RT/Interface/Web.pm:420]
  [/opt/rt5/share/html/autohandler:53] (/opt/rt5/sbin/../lib/RT/Interface/Web/Handler.pm:216)
```

The RT commit that changes the lines trowing the error is https://github.com/bestpractical/rt/commit/46cc17adf200707ead2d69e2dd833467ff5b47a8
We just implemented a workarround in commit https://github.com/gibus/RT-Extension-ConditionalCustomFields/commit/a7474673fb1b61ee2817dcde9c7d81123bbf3a0d as we are not confident about the root cause of the error.