### PR TITLE
Fix support for RT6

### DIFF
--- a/README.RT6
+++ b/README.RT6
@@ -1,0 +1,21 @@
+Notes on using this with RT6:
+
+With RT6 < 6.0.2, you'll need to apply
+https://github.com/bestpractical/rt/commit/e850fd32174689de8d267d0c51d2c94ddf4e0542.patch
+to re-add missing callback Elements/EditCustomFields/AfterCustomFieldValue.
+This patch is not needed for RT 6.0.2 or newer.
+
+Note that this callback is now deprecated in RT 6.0.x, and will be removed as
+of RT 6.2 - and you'll see messages to this effect in your RT log!
+The right way to handle this is to rename the callback to
+Elements/EditCustomField/AfterCustomFieldValue (note the missing 's' in
+EditCustomField!) - but this will break RT5 compatibility, without ensuring
+the old callback only runs on RT < 6 and the new one on RT >= 6.
+
+Note that there's still an unresolved bug with the new custom ticket display layouts
+new to RT6 (in in Admin -> Page Layouts -> Ticket -> Display Layouts): Conditional
+custom fields do not appear to work with this custom layout.  I haven't had a chance
+to look into this issue yet, so anyone installing this update should remain aware of
+this issue.
+
+ -- PinkFreud, 2025-11-18

--- a/html/Callbacks/RT-Extension-ConditionalCustomFields/Admin/Queues/Modify.html/AfterCustomFieldValue
+++ b/html/Callbacks/RT-Extension-ConditionalCustomFields/Admin/Queues/Modify.html/AfterCustomFieldValue
@@ -1,4 +1,4 @@
-<& /Elements/EditConditionalCustomFields, CustomField => $CustomField, Object => $Object, ParentSelector => RT::Handle::cmp_version($RT::VERSION, '5.0.0') < 0 ? 'tr' : 'div.form-row' &>
+<& /Elements/EditConditionalCustomFields, CustomField => $CustomField, Object => $Object, ParentSelector => RT::Handle::cmp_version($RT::VERSION, '5.0.0') < 0 ? 'tr' : 'div.edit-custom-field' &>
 <%ARGS>
 $CustomField
 $Object

--- a/html/Callbacks/RT-Extension-ConditionalCustomFields/Articles/Article/Elements/EditCustomFields/AfterCustomFieldValue
+++ b/html/Callbacks/RT-Extension-ConditionalCustomFields/Articles/Article/Elements/EditCustomFields/AfterCustomFieldValue
@@ -1,4 +1,4 @@
-<& /Elements/EditConditionalCustomFields, CustomField => $CustomField, Object => $Object, ParentSelector => RT::Handle::cmp_version($RT::VERSION, '5.0.0') < 0 ? 'tr' : 'div.form-row' &>
+<& /Elements/EditConditionalCustomFields, CustomField => $CustomField, Object => $Object, ParentSelector => RT::Handle::cmp_version($RT::VERSION, '5.0.0') < 0 ? 'tr' : 'div.edit-custom-field' &>
 <%ARGS>
 $CustomField
 $Object

--- a/html/Callbacks/RT-Extension-ConditionalCustomFields/Elements/EditCustomFields/AfterCustomFieldValue
+++ b/html/Callbacks/RT-Extension-ConditionalCustomFields/Elements/EditCustomFields/AfterCustomFieldValue
@@ -1,4 +1,7 @@
 <& /Elements/EditConditionalCustomFields, CustomField => $CustomField, Object => $Object, Grouping => $Grouping, ParentSelector => '.edit-custom-field' &>
+<%INIT>
+return unless $Object;
+</%INIT>
 <%ARGS>
 $CustomField
 $Object


### PR DESCRIPTION
Patch to fix support with RT 6.0.2 or newer.  6.0.0 and 6.0.1 will also need https://github.com/bestpractical/rt/commit/e850fd32174689de8d267d0c51d2c94ddf4e0542.patch applied to RT to replace a missing callback which breaks this plugin.

This should effectively resolve #14, but see the note in README.RT6 about a feature which still breaks.